### PR TITLE
Make position of output panel configurable

### DIFF
--- a/lib/script-view.js
+++ b/lib/script-view.js
@@ -18,6 +18,10 @@ export default class ScriptView extends MessagePanelView {
     this.scrollTimeout = null;
     this.ansiFilter = new AnsiFilter();
     this.headerView = headerView;
+    this.position = this.parsePositionConfig(atom.config.get('script.position'));
+    atom.config.observe('script.position', (newVal) => {
+      this.position = this.parsePositionConfig(newVal);
+    });
 
     this.showInTab = this.showInTab.bind(this);
     this.setHeaderAndShowExecutionTime = this.setHeaderAndShowExecutionTime.bind(this);
@@ -25,6 +29,26 @@ export default class ScriptView extends MessagePanelView {
     this.addShowInTabIcon();
 
     linkPaths.listen(this.body);
+  }
+
+  parsePositionConfig(value) {
+    // Get the configured position of the view as one of the
+    // valid values of the MessagePanelView.position parameter.
+    let position;
+    switch (value) {
+      case 'Top':
+        return 'top';
+      case 'Bottom':
+        return 'bottom';
+      case 'Left':
+        return 'left';
+      case 'Right':
+        return 'right';
+      default:
+        // Use bottom as the default, because that was the behaviour
+        // before the position became configurable.
+        return 'bottom';
+    }
   }
 
   addShowInTabIcon() {

--- a/lib/script-view.js
+++ b/lib/script-view.js
@@ -34,7 +34,6 @@ export default class ScriptView extends MessagePanelView {
   parsePositionConfig(value) {
     // Get the configured position of the view as one of the
     // valid values of the MessagePanelView.position parameter.
-    let position;
     switch (value) {
       case 'Top':
         return 'top';

--- a/lib/script-view.js
+++ b/lib/script-view.js
@@ -18,9 +18,11 @@ export default class ScriptView extends MessagePanelView {
     this.scrollTimeout = null;
     this.ansiFilter = new AnsiFilter();
     this.headerView = headerView;
-    this.position = this.parsePositionConfig(atom.config.get('script.position'));
+    // Use 'bottom' as the default position, because that was
+    // the behaviour before the position became configurable:
+    this.position = 'bottom';
     atom.config.observe('script.position', (newVal) => {
-      this.position = this.parsePositionConfig(newVal);
+      this.position = newVal;
     });
 
     this.showInTab = this.showInTab.bind(this);
@@ -29,25 +31,6 @@ export default class ScriptView extends MessagePanelView {
     this.addShowInTabIcon();
 
     linkPaths.listen(this.body);
-  }
-
-  parsePositionConfig(value) {
-    // Get the configured position of the view as one of the
-    // valid values of the MessagePanelView.position parameter.
-    switch (value) {
-      case 'Top':
-        return 'top';
-      case 'Bottom':
-        return 'bottom';
-      case 'Left':
-        return 'left';
-      case 'Right':
-        return 'right';
-      default:
-        // Use bottom as the default, because that was the behaviour
-        // before the position became configurable.
-        return 'bottom';
-    }
   }
 
   addShowInTabIcon() {

--- a/lib/script.js
+++ b/lib/script.js
@@ -54,12 +54,12 @@ export const config = {
     description: 'Position of the panel with script output. \
     (Changes to this value will be applied upon reopening the panel.)',
     type: 'string',
-    default: 'Bottom',
+    default: 'bottom',
     enum: [
-      'Top',
-      'Bottom',
-      'Left',
-      'Right',
+      'top',
+      'bottom',
+      'left',
+      'right',
     ],
   },
 }

--- a/lib/script.js
+++ b/lib/script.js
@@ -49,6 +49,19 @@ export const config = {
       'Directory of the script',
     ],
   },
+  position: {
+    title: 'Panel position',
+    description: 'Position of the panel with script output. '
+        + '(Changes to this value will be applied upon reopening the panel.)',
+    type: 'string',
+    default: 'Bottom',
+    enum: [
+      'Top',
+      'Bottom',
+      'Left',
+      'Right',
+    ],
+  },
 }
 
 // For some reason, the text of these options does not show in package settings view

--- a/lib/script.js
+++ b/lib/script.js
@@ -51,8 +51,8 @@ export const config = {
   },
   position: {
     title: 'Panel position',
-    description: 'Position of the panel with script output. '
-        + '(Changes to this value will be applied upon reopening the panel.)',
+    description: 'Position of the panel with script output. \
+    (Changes to this value will be applied upon reopening the panel.)',
     type: 'string',
     default: 'Bottom',
     enum: [


### PR DESCRIPTION
Add a new configuration option to set the position of the output view. This was requested in #1113 but, as far as I can tell, was never implemented (the pull request #1516 did not provide a complete solution).

Note that this change only enables configuring the position, it does not solve the issue with the panel width when on the side, because the atom-message-panel package apparently does not provide for this.