### PR TITLE
fix: if arg is not string assign it

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -164,7 +164,13 @@ export default class Runner {
     args = args.concat(scriptArgs);
 
     const projectPath = this.getProjectPath || '';
-    args = (args.map((arg) => this.fillVarsInArg(arg, codeContext, projectPath)));
+    args = args.map((arg) => {
+      if (typeof arg !== 'string') {
+        // TODO why this happens? // https://github.com/atom-community/atom-script/issues/2082
+        arg = '';
+      }
+      return this.fillVarsInArg(arg, codeContext, projectPath);
+    });
 
     if (!this.scriptOptions.cmd) {
       args = codeContext.shebangCommandArgs().concat(args);


### PR DESCRIPTION
Fixes #2418
Fixes #2417
Fixes #2408
Fixes #2404
Fixes #2396
Fixes #2394
Fixes #2390
Fixes #2386
Fixes #2382
Fixes #2387
Fixes #2377
Fixes #2372
Fixes #2370
Fixes #2082
Fixes #1722
Fixes #1454
