### PR TITLE
chore: use temp instead of tempy

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "atom-message-panel": "1.3.1",
     "atom-space-pen-views-plus": "^3.0.4",
     "strip-ansi": "^6.0.0",
-    "tempy": "^1.0.1",
+    "temp": "^0.9.4",
     "underscore": "^1.12.1",
     "uuid": "^8.3.2"
   },
@@ -38,6 +38,7 @@
     "@types/atom": "^1.40.10",
     "@types/jasmine": "^3.6.7",
     "@types/node": "^14.14.35",
+    "@types/temp": "^0.8.34",
     "@types/underscore": "^1.11.0",
     "@types/uuid": "^8.3.0",
     "eslint": "^7.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,14 @@ dependencies:
   atom-message-panel: 1.3.1
   atom-space-pen-views-plus: 3.0.4
   strip-ansi: 6.0.0
-  tempy: 1.0.1
+  temp: 0.9.4
   underscore: 1.12.1
   uuid: 8.3.2
 devDependencies:
   '@types/atom': 1.40.10
   '@types/jasmine': 3.6.7
   '@types/node': 14.14.35
+  '@types/temp': 0.8.34
   '@types/underscore': 1.11.0
   '@types/uuid': 8.3.0
   eslint: 7.22.0
@@ -1092,11 +1093,13 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
       run-parallel: 1.2.0
+    dev: true
     engines:
       node: '>= 8'
     resolution:
       integrity: sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
   /@nodelib/fs.stat/2.0.4:
+    dev: true
     engines:
       node: '>= 8'
     resolution:
@@ -1105,6 +1108,7 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.4
       fastq: 1.11.0
+    dev: true
     engines:
       node: '>= 8'
     resolution:
@@ -1131,6 +1135,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
+  /@types/temp/0.8.34:
+    dependencies:
+      '@types/node': 14.14.35
+    dev: true
+    resolution:
+      integrity: sha512-oLa9c5LHXgS6UimpEVp08De7QvZ+Dfu5bMQuWyMhf92Z26Q10ubEMOWy9OEfUdzW7Y/sDWVHmUaLFtmnX/2j0w==
   /@types/underscore/1.11.0:
     dev: true
     resolution:
@@ -1259,15 +1269,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-  /aggregate-error/3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
   /ajv/6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -1402,6 +1403,7 @@ packages:
     resolution:
       integrity: sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==
   /array-union/2.1.0:
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -1794,12 +1796,6 @@ packages:
     optional: true
     resolution:
       integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
-  /clean-stack/2.2.0:
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
   /cli/1.0.1:
     dependencies:
       exit: 0.1.2
@@ -1928,12 +1924,6 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
-  /crypto-random-string/2.0.0:
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
   /d/0.1.1:
     dependencies:
       es5-ext: 0.10.53
@@ -2018,24 +2008,10 @@ packages:
     optional: true
     resolution:
       integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
-  /del/6.0.0:
-    dependencies:
-      globby: 11.0.2
-      graceful-fs: 4.2.5
-      is-glob: 4.0.1
-      is-path-cwd: 2.2.0
-      is-path-inside: 3.0.2
-      p-map: 4.0.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-    dev: false
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==
   /dir-glob/3.0.1:
     dependencies:
       path-type: 4.0.0
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -2689,6 +2665,7 @@ packages:
       merge2: 1.4.1
       micromatch: 4.0.2
       picomatch: 2.2.2
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -2704,6 +2681,7 @@ packages:
   /fastq/1.11.0:
     dependencies:
       reusify: 1.0.4
+    dev: true
     resolution:
       integrity: sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
   /file-entry-cache/6.0.1:
@@ -2845,6 +2823,7 @@ packages:
   /glob-parent/5.1.2:
     dependencies:
       is-glob: 4.0.1
+    dev: true
     engines:
       node: '>= 6'
     resolution:
@@ -2894,6 +2873,7 @@ packages:
       ignore: 5.1.8
       merge2: 1.4.1
       slash: 3.0.0
+    dev: true
     engines:
       node: '>=10'
     resolution:
@@ -3007,6 +2987,7 @@ packages:
     resolution:
       integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
   /ignore/5.1.8:
+    dev: true
     engines:
       node: '>= 4'
     resolution:
@@ -3026,12 +3007,6 @@ packages:
       node: '>=0.8.19'
     resolution:
       integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=
-  /indent-string/4.0.0:
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
   /inflight/1.0.6:
     dependencies:
       once: 1.4.0
@@ -3240,18 +3215,6 @@ packages:
       node: '>=0.12.0'
     resolution:
       integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-  /is-path-cwd/2.2.0:
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
-  /is-path-inside/3.0.2:
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
   /is-plain-object/2.0.4:
     dependencies:
       isobject: 3.0.1
@@ -3270,12 +3233,6 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
-  /is-stream/2.0.0:
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
   /is-string/1.0.5:
     dev: true
     engines:
@@ -3559,6 +3516,7 @@ packages:
     resolution:
       integrity: sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   /merge2/1.4.1:
+    dev: true
     engines:
       node: '>= 8'
     resolution:
@@ -3588,6 +3546,7 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.2.2
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -3614,6 +3573,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-wyDvYbUvKJj1IuF9i7xtUG2EJbY=
+  /mkdirp/0.5.5:
+    dependencies:
+      minimist: 1.2.5
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   /ms/2.0.0:
     resolution:
       integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
@@ -3796,14 +3762,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
-  /p-map/4.0.0:
-    dependencies:
-      aggregate-error: 3.1.0
-    dev: false
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   /p-try/1.0.0:
     dev: true
     engines:
@@ -3867,6 +3825,7 @@ packages:
     resolution:
       integrity: sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
   /path-type/4.0.0:
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -3955,6 +3914,7 @@ packages:
     resolution:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
   /queue-microtask/1.2.2:
+    dev: true
     resolution:
       integrity: sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==
   /react-is/16.13.1:
@@ -4160,20 +4120,30 @@ packages:
     resolution:
       integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
   /reusify/1.0.4:
+    dev: true
     engines:
       iojs: '>=1.0.0'
       node: '>=0.10.0'
     resolution:
       integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+  /rimraf/2.6.3:
+    dependencies:
+      glob: 7.1.6
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   /rimraf/3.0.2:
     dependencies:
       glob: 7.1.6
+    dev: true
     hasBin: true
     resolution:
       integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   /run-parallel/1.2.0:
     dependencies:
       queue-microtask: 1.2.2
+    dev: true
     resolution:
       integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   /safe-buffer/5.1.2:
@@ -4256,6 +4226,7 @@ packages:
     resolution:
       integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
   /slash/3.0.0:
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -4499,24 +4470,15 @@ packages:
       node: '>=10.0.0'
     resolution:
       integrity: sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==
-  /temp-dir/2.0.0:
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
-  /tempy/1.0.1:
+  /temp/0.9.4:
     dependencies:
-      del: 6.0.0
-      is-stream: 2.0.0
-      temp-dir: 2.0.0
-      type-fest: 0.16.0
-      unique-string: 2.0.0
+      mkdirp: 0.5.5
+      rimraf: 2.6.3
     dev: false
     engines:
-      node: '>=10'
+      node: '>=6.0.0'
     resolution:
-      integrity: sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==
+      integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==
   /text-table/0.2.0:
     dev: true
     resolution:
@@ -4602,12 +4564,6 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
-  /type-fest/0.16.0:
-    dev: false
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==
   /type-fest/0.20.2:
     dev: true
     engines:
@@ -4697,14 +4653,6 @@ packages:
     optional: true
     resolution:
       integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
-  /unique-string/2.0.0:
-    dependencies:
-      crypto-random-string: 2.0.0
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   /universalify/2.0.0:
     dev: false
     engines:
@@ -4834,6 +4782,7 @@ specifiers:
   '@types/atom': ^1.40.10
   '@types/jasmine': ^3.6.7
   '@types/node': ^14.14.35
+  '@types/temp': ^0.8.34
   '@types/underscore': ^1.11.0
   '@types/uuid': ^8.3.0
   ansi-to-html: ^0.6.14
@@ -4845,6 +4794,6 @@ specifiers:
   prettier: ^2.2.1
   prettier-config-atomic: ^1.0.1
   strip-ansi: ^6.0.0
-  tempy: ^1.0.1
+  temp: ^0.9.4
   underscore: ^1.12.1
   uuid: ^8.3.2

--- a/spec/code-context-spec.js
+++ b/spec/code-context-spec.js
@@ -1,7 +1,9 @@
 "use babel" // TODO
 
-/* eslint-disable no-invalid-this */ import tempy from "tempy"
+/* eslint-disable no-invalid-this */
 import path from "path"
+import temp from "temp"
+temp.track()
 
 import CodeContext from "../lib/code-context"
 
@@ -10,7 +12,7 @@ describe("CodeContext", () => {
   let testFilePath
 
   beforeEach(() => {
-    testFilePath = path.join(tempy.directory(), testFile)
+    testFilePath = path.join(temp.mkdirSync(""), testFile)
     this.codeContext = new CodeContext(testFile, testFilePath, null)
     // TODO: Test using an actual editor or a selection?
     this.dummyTextSource = {}

--- a/spec/grammars-spec.js
+++ b/spec/grammars-spec.js
@@ -1,7 +1,9 @@
 "use babel" // TODO
 
-/* eslint-disable no-invalid-this */ import tempy from "tempy"
+/* eslint-disable no-invalid-this */
 import path from "path"
+import temp from "temp"
+temp.track()
 
 import CodeContext from "../lib/code-context"
 import OperatingSystem from "../lib/grammar-utils/operating-system"
@@ -12,7 +14,7 @@ describe("grammarMap", () => {
   let testFilePath
 
   beforeEach(() => {
-    testFilePath = path.join(tempy.directory(), testFile)
+    testFilePath = path.join(temp.mkdirSync(""), testFile)
     this.codeContext = new CodeContext(testFile, testFilePath, null)
     // TODO: Test using an actual editor or a selection?
     this.dummyTextSource = {}


### PR DESCRIPTION
We will need to set the root directory and prefix, which `tempy` doesn't allow, so we can't use it [inside `GrammarUtils`](https://github.com/atom-community/atom-script/blob/eb8bea2794e4280baf63b053c7688225e0e15fff/lib/grammar-utils.js#L11). It also doesn't provide cleanup options like `temp` does.

https://github.com/sindresorhus/tempy/pull/32
https://github.com/sindresorhus/tempy/pull/33

Also, `tempy` is ~3.5 times bigger than `temp`.

https://github.com/sindresorhus/tempy/issues/27
https://bundlephobia.com/result?p=temp@0.9.4 -> 37 KB
https://bundlephobia.com/result?p=tempy@1.0.1  -> 130KB
