### PR TITLE
Fix Java Execution + Support UF8 strings

### DIFF
--- a/examples/HelloWorld.java
+++ b/examples/HelloWorld.java
@@ -1,5 +1,6 @@
 class HelloWorld {
     public static void main(String[] args) {
         System.out.println("Hello, World!");
+        System.out.println("سلام");
     }
 }

--- a/lib/grammars/java.js
+++ b/lib/grammars/java.js
@@ -20,7 +20,7 @@ export const Java = {
       const classPackages = GrammarUtils.Java.getClassPackage(context)
       const sourcePath = GrammarUtils.Java.getProjectPath(context)
       if (windows) {
-        return [`/c javac -Xlint ${context.filename} && java ${className}`]
+        return [`/c javac ーJ-Dfile.encoding=UTF-8 -Xlint ${context.filename} && java -Dfile.encoding=UTF-8 ${className}`]
       } else {
         return [
           "-c",

--- a/lib/grammars/java.js
+++ b/lib/grammars/java.js
@@ -1,11 +1,4 @@
 "use babel"
-
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 import path from "path"
 import GrammarUtils from "../grammar-utils"
 const { command } = GrammarUtils

--- a/lib/grammars/java.js
+++ b/lib/grammars/java.js
@@ -16,6 +16,18 @@ function JavaArgs(sourcePath, filepath, className, classPackages, tempFolder) {
 }
 
 export const Java = {
+  "Selection Based": {
+    command,
+    args(context) {
+      const code = context.getCode()
+      const tmpFile = GrammarUtils.createTempFileWithCode(code, ".java")
+      const sourcePath = GrammarUtils.Java.getProjectPath(context)
+      const className = GrammarUtils.Java.getClassName(context)
+      const classPackages = GrammarUtils.Java.getClassPackage(context)
+      const tempFolder = GrammarUtils.createTempFolder("jar-")
+      return JavaArgs(sourcePath, tmpFile, className, classPackages, tempFolder)
+    },
+  },
   "File Based": {
     command,
     args(context) {

--- a/lib/grammars/java.js
+++ b/lib/grammars/java.js
@@ -19,14 +19,9 @@ export const Java = {
       const className = GrammarUtils.Java.getClassName(context)
       const classPackages = GrammarUtils.Java.getClassPackage(context)
       const sourcePath = GrammarUtils.Java.getProjectPath(context)
-      if (windows) {
-        return [`/c javac ーJ-Dfile.encoding=UTF-8 -Xlint ${context.filename} && java -Dfile.encoding=UTF-8 ${className}`]
-      } else {
-        return [
-          "-c",
-          `javac -J-Dfile.encoding=UTF-8 -sourcepath '${sourcePath}' -d /tmp '${context.filepath}' && java -Dfile.encoding=UTF-8 -cp /tmp:%CLASSPATH ${classPackages}${className}`,
-        ]
-      }
+      const tempFolder = GrammarUtils.createTempFolder("jar-")
+      const cmd = `javac -encoding UTF-8 -sourcepath '${sourcePath}' -d '${tempFolder}' '${context.filepath}' && java -D'file.encoding'='UTF-8' -cp '${tempFolder}' ${classPackages}${className}`
+      return GrammarUtils.formatArgs(cmd)
     },
   },
 }

--- a/lib/grammars/java.js
+++ b/lib/grammars/java.js
@@ -10,16 +10,20 @@ import path from "path"
 import GrammarUtils from "../grammar-utils"
 const { command } = GrammarUtils
 
+function JavaArgs(sourcePath, filepath, className, classPackages, tempFolder) {
+  const cmd = `javac -encoding UTF-8 -sourcepath '${sourcePath}' -d '${tempFolder}' '${filepath}' && java -D'file.encoding'='UTF-8' -cp '${tempFolder}' ${classPackages}${className}`
+  return GrammarUtils.formatArgs(cmd)
+}
+
 export const Java = {
   "File Based": {
     command,
     args(context) {
+      const sourcePath = GrammarUtils.Java.getProjectPath(context)
       const className = GrammarUtils.Java.getClassName(context)
       const classPackages = GrammarUtils.Java.getClassPackage(context)
-      const sourcePath = GrammarUtils.Java.getProjectPath(context)
       const tempFolder = GrammarUtils.createTempFolder("jar-")
-      const cmd = `javac -encoding UTF-8 -sourcepath '${sourcePath}' -d '${tempFolder}' '${context.filepath}' && java -D'file.encoding'='UTF-8' -cp '${tempFolder}' ${classPackages}${className}`
-      return GrammarUtils.formatArgs(cmd)
+      return JavaArgs(sourcePath, context.filepath, className, classPackages, tempFolder)
     },
   },
 }

--- a/lib/grammars/java.js
+++ b/lib/grammars/java.js
@@ -10,7 +10,11 @@ import path from "path"
 import GrammarUtils from "../grammar-utils"
 const { command } = GrammarUtils
 
-function JavaArgs(sourcePath, filepath, className, classPackages, tempFolder) {
+function JavaArgs(filepath, context) {
+  const sourcePath = GrammarUtils.Java.getProjectPath(context)
+  const className = GrammarUtils.Java.getClassName(context)
+  const classPackages = GrammarUtils.Java.getClassPackage(context)
+  const tempFolder = GrammarUtils.createTempFolder("jar-")
   const cmd = `javac -encoding UTF-8 -sourcepath '${sourcePath}' -d '${tempFolder}' '${filepath}' && java -D'file.encoding'='UTF-8' -cp '${tempFolder}' ${classPackages}${className}`
   return GrammarUtils.formatArgs(cmd)
 }
@@ -21,21 +25,13 @@ export const Java = {
     args(context) {
       const code = context.getCode()
       const tmpFile = GrammarUtils.createTempFileWithCode(code, ".java")
-      const sourcePath = GrammarUtils.Java.getProjectPath(context)
-      const className = GrammarUtils.Java.getClassName(context)
-      const classPackages = GrammarUtils.Java.getClassPackage(context)
-      const tempFolder = GrammarUtils.createTempFolder("jar-")
-      return JavaArgs(sourcePath, tmpFile, className, classPackages, tempFolder)
+      return JavaArgs(tmpFile, context)
     },
   },
   "File Based": {
     command,
     args(context) {
-      const sourcePath = GrammarUtils.Java.getProjectPath(context)
-      const className = GrammarUtils.Java.getClassName(context)
-      const classPackages = GrammarUtils.Java.getClassPackage(context)
-      const tempFolder = GrammarUtils.createTempFolder("jar-")
-      return JavaArgs(sourcePath, context.filepath, className, classPackages, tempFolder)
+      return JavaArgs(context.filepath, context)
     },
   },
 }

--- a/lib/grammars/java.js
+++ b/lib/grammars/java.js
@@ -10,8 +10,6 @@ import path from "path"
 import GrammarUtils from "../grammar-utils"
 const { command } = GrammarUtils
 
-const windows = GrammarUtils.OperatingSystem.isWindows()
-
 export const Java = {
   "File Based": {
     command,


### PR DESCRIPTION
Quick fix for the issue #1166, Java build in non-English editions of Window will result garbled message, stdout and stderr displayed.
Please note that this fix would have further issue: if user's final target deployment would have different encodings from all-UTF-8 setup, (such as "normal" Windows cmd.exe, they normally have ANSI encodings for average users) so testing and evaluating might become more difficult.)

Steps to reproduce:
　　Atom: 1.57.0 (Windows x64)
       Script: 3.31.3
       Grammar: java.js
       Java: AdoptOpenJDK 11.0.9.1 (HotSpot)