### PR TITLE
fix: add xlint and file.encoding to Java

### DIFF
--- a/lib/grammars/java.js
+++ b/lib/grammars/java.js
@@ -8,7 +8,7 @@ function JavaArgs(filepath, context) {
   const className = GrammarUtils.Java.getClassName(context)
   const classPackages = GrammarUtils.Java.getClassPackage(context)
   const tempFolder = GrammarUtils.createTempFolder("jar-")
-  const cmd = `javac -encoding UTF-8 -sourcepath '${sourcePath}' -d '${tempFolder}' '${filepath}' && java -D'file.encoding'='UTF-8' -cp '${tempFolder}' ${classPackages}${className}`
+  const cmd = `javac -encoding UTF-8 -J-Dfile.encoding=UTF-8 -Xlint -sourcepath '${sourcePath}' -d '${tempFolder}' '${filepath}' && java -Dfile.encoding=UTF-8 -cp '${tempFolder}' ${classPackages}${className}`
   return GrammarUtils.formatArgs(cmd)
 }
 


### PR DESCRIPTION
Adding back UTF-8 encoding related options and -Xlint. Tested on Windows 10 and Ubuntu 21.04.